### PR TITLE
handle run_migrations and collect_static_files bool value

### DIFF
--- a/pystrano/config.py
+++ b/pystrano/config.py
@@ -56,12 +56,12 @@ class PystranoConfig(object):
         if hasattr(self, "service_file"):
             setattr(self, "service_file_name", path.basename(self.service_file))
 
-        if hasattr(self, "run_migrations"):
+        if hasattr(self, "run_migrations") and type(self.run_migrations) == str:
             setattr(self, "run_migrations", self.run_migrations.lower() == "true")
         else:
             setattr(self, "run_migrations", False)
 
-        if hasattr(self, "collect_static_files"):
+        if hasattr(self, "collect_static_files") and type(self.collect_static_files) == str:
             setattr(self, "collect_static_files", self.collect_static_files.lower() == "true")
         else:
             setattr(self, "collect_static_files", False)


### PR DESCRIPTION
Fixes error when bool values are used in `run_migrations` or `collect_static_files` in deploy config (from https://pystrano.com/ example)

<img width="504" height="185" alt="Screenshot 2026-03-11 at 00 48 16" src="https://github.com/user-attachments/assets/e117f296-5ab9-4f62-a8bf-b939f20510b3" />

Error:

<img width="643" height="70" alt="Screenshot 2026-03-11 at 00 46 51" src="https://github.com/user-attachments/assets/6e40453e-b7d5-48d4-95c8-3c8873b82cb3" />

These changes fix the issue